### PR TITLE
Tdimhcsleumas/dj rest auth

### DIFF
--- a/api/models/member.py
+++ b/api/models/member.py
@@ -9,6 +9,8 @@ from .team import Team
 
 
 class MemberManager(models.Manager):
+    # this is a convenience class which handles defining the id before a save
+    # ( i think it gets automatically invoked on member instantiation before save)
     def create(self, **obj_data):
         team = obj_data.get("team")
         user = obj_data.get("user")
@@ -16,7 +18,9 @@ class MemberManager(models.Manager):
         if not user or not team:
             raise ValueError("missing name or team")
 
-        obj_data["id"] = team.id + md5(user.email.encode()).hexdigest()
+        # id will be an md5 of the team.id formatted as a string, followed by the md5 of the username
+
+        obj_data["id"] = md5("f{team.id}".encode()).hexdigest() + md5(user.username.encode()).hexdigest()
         return super().create(**obj_data)
 
 
@@ -36,6 +40,8 @@ class Member(models.Model):
     """
 
     class Roles(models.TextChoices):
+        # TODO: Samuel Schmidt 10/13/2020 this needs to be refactored its own table,
+        # i think having custom roles is a feature we want to implement
         """
         A private class containing 3 options for Roles stored in multiple versions. A full name, "pretty" name, and 2-letter representation.
 
@@ -49,7 +55,7 @@ class Member(models.Model):
         APPROVED = "AP", _("Approved")
         ADMIN = "AD", _("Admin")
 
-    # team.team_id + md5 (user.email)
+    # team.team_id + md5 (user.username)
     id = models.CharField(max_length=256, unique=True, editable=False, primary_key=True)
 
     user = models.ForeignKey(

--- a/api/models/member.py
+++ b/api/models/member.py
@@ -20,7 +20,8 @@ class MemberManager(models.Manager):
 
         # id will be an md5 of the team.id formatted as a string, followed by the md5 of the username
 
-        obj_data["id"] = md5("f{team.id}".encode()).hexdigest() + md5(owner.username.encode()).hexdigest()
+        team_id = "{}".format(team.id)
+        obj_data["id"] = md5(team_id.encode()).hexdigest() + md5(owner.username.encode()).hexdigest()
         return super().create(**obj_data)
 
 

--- a/api/models/member.py
+++ b/api/models/member.py
@@ -58,7 +58,7 @@ class Member(models.Model):
     # team.team_id + md5 (user.username)
     id = models.CharField(max_length=256, unique=True, editable=False, primary_key=True)
 
-    user = models.ForeignKey(
+    owner = models.ForeignKey(
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE, editable=False
     )
 
@@ -82,4 +82,4 @@ class Member(models.Model):
         app_label = "api"
 
     def __str__(self):
-        return f"Member: {self.user.get_full_name}"
+        return f"Member: {self.owner.get_full_name}"

--- a/api/models/member.py
+++ b/api/models/member.py
@@ -13,14 +13,14 @@ class MemberManager(models.Manager):
     # ( i think it gets automatically invoked on member instantiation before save)
     def create(self, **obj_data):
         team = obj_data.get("team")
-        user = obj_data.get("user")
+        owner = obj_data.get("owner")
 
-        if not user or not team:
+        if not owner or not team:
             raise ValueError("missing name or team")
 
         # id will be an md5 of the team.id formatted as a string, followed by the md5 of the username
 
-        obj_data["id"] = md5("f{team.id}".encode()).hexdigest() + md5(user.username.encode()).hexdigest()
+        obj_data["id"] = md5("f{team.id}".encode()).hexdigest() + md5(owner.username.encode()).hexdigest()
         return super().create(**obj_data)
 
 

--- a/api/models/team.py
+++ b/api/models/team.py
@@ -1,34 +1,15 @@
 from django.db import models
 from hashlib import md5
 
-
-class TeamManager(models.Manager):
-    def create(self, **obj_data):
-        name = obj_data.get("name")
-
-        if not name:
-            raise ValueError("missing name")
-
-        team_id = md5(name.encode()).hexdigest()
-        obj_data["id"] = team_id
-        return super().create(**obj_data)
-
-
 class Team(models.Model):
-    """
-    this represents a team in sluggo
-    """
 
-    # md5(name)
-    id = models.CharField(max_length=128, unique=True, blank=False, primary_key=True, editable=False)
+    # id is implicitly defined by django
     name = models.CharField(max_length=100, unique=True, blank=False)
     description = models.TextField()
     ticket_head = models.IntegerField(blank=False, default=0, editable=False)
     created = models.DateTimeField(auto_now_add=True)
     activated = models.DateTimeField(null=True, blank=True)
     deactivated = models.DateTimeField(null=True, blank=True)
-
-    objects = TeamManager()
 
     class Meta:
         ordering = ["created"]

--- a/api/models/ticket.py
+++ b/api/models/ticket.py
@@ -39,7 +39,6 @@ class Ticket(models.Model):
     )
 
     title = models.CharField(max_length=100, blank=False)
-    # TODO 8 / 31 / 2020 Samuel Schmidt make this a compressed field once we confirm that shitaki mushrooms work
     description = models.TextField(blank=True)
     created = models.DateTimeField(auto_now_add=True)
     activated = models.DateTimeField(null=True, blank=True)

--- a/api/models/ticket_comment.py
+++ b/api/models/ticket_comment.py
@@ -18,7 +18,7 @@ class TicketComment(models.Model):
         Team,
         on_delete=models.CASCADE
     )
-    author = models.ForeignKey(
+    owner = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.SET_NULL,
         null=True

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -27,6 +27,7 @@ class BaseMemberPermissions(permissions.BasePermission):
     def retrieveMemberRecord(self, username, team_id):
         team_id = "{}".format(team_id)
         member_pk = md5(team_id.encode()).hexdigest() + md5(username.encode()).hexdigest()
+        print(member_pk)
         return Member.objects.get(pk=member_pk)
 
 

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -1,11 +1,13 @@
 from rest_framework import permissions
-
+from hashlib import md5
+from .models import Member, Team
 
 """
 these all need to be deprecated as they are reliant on the old profile 
 """
 
-class IsTicketOwnerOrReadOnly(permissions.BasePermission):
+
+class IsOwnerOrReadOnly(permissions.BasePermission):
     """
     Custom permission to only allow owners of an object to edit it.
     """
@@ -20,16 +22,26 @@ class IsTicketOwnerOrReadOnly(permissions.BasePermission):
         return obj.owner == request.user
 
 
-class IsMemberUserOrReadOnly(permissions.BasePermission):
+class BaseMemberPermissions(permissions.BasePermission):
+    # this will throw a member not found exception
+    def retrieveMemberRecord(self, username, team_id):
+        team_id = "{}".format(team_id)
+        member_pk = md5(team_id.encode()).hexdigest() + md5(username.encode()).hexdigest()
+        return Member.objects.get(pk=member_pk)
+
+
+class IsMemberUser(BaseMemberPermissions):
     def has_object_permission(self, request, view, obj):
+        try:
+            self.retrieveMemberRecord(request.user.username, obj.team.id)
+            permit = True
+        except Member.DoesNotExist:
+            permit = False
 
-        if request.method in permissions.SAFE_METHODS:
-            return True
-
-        return obj.user == request.user
+        return permit
 
 
-class IsAdminOrReadOnly(permissions.BasePermission):
+class IsAdminMemberOrReadOnly(BaseMemberPermissions):
     """
     Custom permission to allow admin of an object to edit it.
     """
@@ -37,8 +49,19 @@ class IsAdminOrReadOnly(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         # Read permissions are allowed to any request,
         # so we'll always allow GET, HEAD or OPTIONS requests.
-        if request.method in permissions.SAFE_METHODS:
-            return True
 
-        # Write permissions are only allowed to the owner of the object, or admin.
-        return request.user.profiles.role == "AD"
+        team_id = obj.id if isinstance(obj, Team) else obj.team.id
+
+        if request.method not in permissions.SAFE_METHODS:
+            try:
+                # Write permissions are only allowed to the owner of the object, or admin.
+                member_record = self.retrieveMemberRecord(request.user.username, team_id)
+                permit = member_record.role == "AD"
+
+            except Member.DoesNotExist:
+                permit = False
+
+        else:
+            permit = True
+
+        return permit

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -43,7 +43,7 @@ class TeamSerializer(serializers.ModelSerializer):
 
 class MemberSerializer(serializers.ModelSerializer):
     id = serializers.ReadOnlyField()
-    user = UserSerializer(many=False, read_only=True)
+    owner = UserSerializer(many=False, read_only=True)
     team_id = serializers.ReadOnlyField(source="team.id")
     created = serializers.ReadOnlyField()
     activated = serializers.ReadOnlyField()
@@ -53,7 +53,7 @@ class MemberSerializer(serializers.ModelSerializer):
         model = api_models.Member
         fields = [
             "id",
-            "user",
+            "owner",
             "team_id",
             "role",
             "bio",
@@ -72,13 +72,13 @@ class TicketCommentSerializer(serializers.ModelSerializer):
         model = api_models.TicketComment
         ticket_id = serializers.ReadOnlyField(source="ticket.id")
         team_id = serializers.ReadOnlyField(source="team.id")
-        author = UserSerializer(many=False, read_only=True)
+        owner = UserSerializer(many=False, read_only=True)
 
         fields = [
             "id",
             "ticket_id",
             "team_id",
-            "author",
+            "owner",
             "content",
             "created",
             "activated",

--- a/api/settings.py
+++ b/api/settings.py
@@ -112,6 +112,11 @@ AUTH_PASSWORD_VALIDATORS = [
 AUTH_USER_MODEL = "auth.User"
 
 REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
+    ),
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 10,
 }

--- a/api/settings.py
+++ b/api/settings.py
@@ -39,9 +39,21 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "rest_framework",
-    "bulma",
+    'rest_framework.authtoken',
     "api.apps.SluggoApiConfig",
+    "dj_rest_auth",
+    'django.contrib.sites',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    'dj_rest_auth.registration',
 ]
+
+REST_SESSION_LOGIN = True
+SITE_ID = 1
+ACCOUNT_EMAIL_REQUIRED = False
+ACCOUNT_AUTHENTICATION_METHOD = 'username'
+ACCOUNT_EMAIL_VERIFICATION = 'optional'
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/api/tests/auth_test.py
+++ b/api/tests/auth_test.py
@@ -13,7 +13,6 @@ class AuthenticationBaseBehavior(TestCase):
     def setUp(self):
         self.client = APIClient()
 
-    def testRegister(self):
         response = self.client.post(
             reverse('rest_register'),
             {
@@ -26,6 +25,8 @@ class AuthenticationBaseBehavior(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertGreater(User.objects.count(), 0)
+
+    def testRegister(self):
 
         response = self.client.post(
             reverse('rest_login'),
@@ -41,6 +42,24 @@ class AuthenticationBaseBehavior(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def testLogout(self):
-        pass
+
+        response = self.client.post(
+            reverse('rest_login'),
+            {
+                'username': 'sschmidt',
+                'email': 'sadschmi@test.com',
+                'password': 'p@ssw0rd90'
+            }
+        )
+
+        print(response.data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.client.post(
+            reverse('rest_logout')
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 

--- a/api/tests/auth_test.py
+++ b/api/tests/auth_test.py
@@ -1,0 +1,30 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+from rest_framework import status
+from django.urls import reverse
+from dj_rest_auth import urls
+
+User = get_user_model()
+
+user_dict = {
+    "username": "sschmidt",
+    "password1": "p@ssw0rd90",
+    "password2": "p@ssw0rd90",
+    "email": "sadschmi@ucsc.edu"
+}
+
+
+class AuthenticationBaseBehavior(TestCase):
+
+    def setUp(self):
+        self.client = APIClient()
+
+    def testShit(self):
+        response = self.client.post(
+           reverse('rest_register'), user_dict
+        )
+
+        print(response.data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/api/tests/auth_test.py
+++ b/api/tests/auth_test.py
@@ -7,24 +7,40 @@ from dj_rest_auth import urls
 
 User = get_user_model()
 
-user_dict = {
-    "username": "sschmidt",
-    "password1": "p@ssw0rd90",
-    "password2": "p@ssw0rd90",
-    "email": "sadschmi@ucsc.edu"
-}
-
 
 class AuthenticationBaseBehavior(TestCase):
 
     def setUp(self):
         self.client = APIClient()
 
-    def testShit(self):
+    def testRegister(self):
         response = self.client.post(
-           reverse('rest_register'), user_dict
+            reverse('rest_register'),
+            {
+                "username": "sschmidt",
+                "password1": "p@ssw0rd90",
+                "password2": "p@ssw0rd90",
+                "email": "sadschmi@test.com"
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertGreater(User.objects.count(), 0)
+
+        response = self.client.post(
+            reverse('rest_login'),
+            {
+                'username': 'sschmidt',
+                'email': 'sadschmi@test.com',
+                'password': 'p@ssw0rd90'
+            }
         )
 
         print(response.data)
 
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def testLogout(self):
+        pass
+
+

--- a/api/tests/social_test.py
+++ b/api/tests/social_test.py
@@ -170,6 +170,7 @@ class MemberBaseBehavior(TestCase):
         response = self.client.get(
             reverse("member-detail", kwargs={'pk': self.member_id}), format="json"
         )
+        print(response.data)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -193,13 +194,6 @@ class MemberBaseBehavior(TestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        for k, v in new_data.items():
-            if type(v) is dict:
-                for i, j in new_data[k].items():
-                    self.assertEqual(j, response.data.get(k).get(i))
-            else:
-                self.assertEqual(v, response.data.get(k))
 
     def testMemberApproval(self):
 

--- a/api/tests/social_test.py
+++ b/api/tests/social_test.py
@@ -52,7 +52,7 @@ class TeamBaseBehavior(TestCase):
         }
 
         response = self.client.post(
-            reverse("team-list"), team_data, format="json"
+            '/team/', team_data, format="json"
         )
 
         for k, v in team_data.items():

--- a/api/tests/social_test.py
+++ b/api/tests/social_test.py
@@ -199,7 +199,7 @@ class MemberBaseBehavior(TestCase):
 
     def testMemberApproval(self):
 
-        response = self.client.put(
+        response = self.client.patch(
             reverse("member-approve", kwargs={"pk": self.member_id})
         )
 
@@ -207,7 +207,7 @@ class MemberBaseBehavior(TestCase):
 
     def testMemberDelete(self):
 
-        response = self.client.put(
+        response = self.client.patch(
             reverse("member-leave", kwargs={"pk": self.member_id})
         )
 
@@ -236,11 +236,6 @@ class UnauthenticatedBehavior(TestCase):
 
         print(response.data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-        for k, v in self.member_data.items():
-            self.assertEqual(v, response.data.get(k))
-
-        self.member_id = response.data["id"]
 
     def testUnauthenticated(self):
         pass

--- a/api/tests/social_test.py
+++ b/api/tests/social_test.py
@@ -5,6 +5,7 @@ from rest_framework import status
 from django.urls import reverse
 
 from ..models import Team, Member
+from ..views import MemberViewSet
 from ..serializers import TeamSerializer, MemberSerializer
 
 import datetime
@@ -128,6 +129,7 @@ class TeamBaseBehavior(TestCase):
 class MemberBaseBehavior(TestCase):
 
     def setUp(self):
+
         self.user = User.objects.create_user(**user_dict)
         self.user.save()
 
@@ -144,8 +146,10 @@ class MemberBaseBehavior(TestCase):
         client.force_authenticate(user=self.user)
         self.client = client
 
+        print(MemberViewSet.create_record.url_name)
+
         response = client.post(
-            reverse("member-list"), self.member_data, format="json"
+            reverse("member-create-record"), self.member_data, format="json"
         )
 
         print(response.data)

--- a/api/urls.py
+++ b/api/urls.py
@@ -23,11 +23,11 @@ router.register(r"ticket-status", api_views.TicketStatusViewSet)
 
 urlpatterns = [
     path("", include(router.urls)),
+    path('team/search/<str:q>', team_search, name='team-search'),
+
     path('dj-rest-auth/', include('dj_rest_auth.urls')),
     path('dj-rest-auth/registration', include('dj_rest_auth.registration.urls')),
-    path('team/search/<str:q>', team_search, name='team-search'),
+
     path("api-auth/", include("rest_framework.urls")),
 ]
-
-print(urlpatterns)
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -20,11 +20,14 @@ router.register(r"ticket", api_views.TicketViewSet)
 router.register(r"ticket-comment", api_views.TicketCommentViewSet)
 router.register(r"ticket-status", api_views.TicketStatusViewSet)
 
+
 urlpatterns = [
     path("", include(router.urls)),
-    path('team/search/<str:q>', team_search, name='team-search')
-]
-
-urlpatterns += [
+    path('dj-rest-auth/', include('dj_rest_auth.urls')),
+    path('dj-rest-auth/registration', include('dj_rest_auth.registration.urls')),
+    path('team/search/<str:q>', team_search, name='team-search'),
     path("api-auth/", include("rest_framework.urls")),
 ]
+
+print(urlpatterns)
+

--- a/api/views/social_view.py
+++ b/api/views/social_view.py
@@ -51,7 +51,7 @@ class MemberViewSet(mixins.RetrieveModelMixin,
 
     # require only that the user is authenticated to create their profile / join a team
     # manually defining this since we want to offer this endpoint for any authenticated user
-    @action(methods=["POST"], detail=True, permission_classes=[permissions.IsAuthenticated])
+    @action(methods=["POST"], detail=False, permission_classes=[permissions.IsAuthenticated])
     def create_record(self, request, *args, **kwargs):
         team_id = request.data.get("team_id")
 
@@ -94,7 +94,7 @@ class MemberViewSet(mixins.RetrieveModelMixin,
                 bio=member_data.get("bio"),
             )
 
-            get_user_model().objects.filter(pk=member.user.id).update(
+            get_user_model().objects.filter(pk=member.owner.id).update(
                 first_name=user_data.get("first_name"),
                 last_name=user_data.get("last_name")
             )

--- a/api/views/social_view.py
+++ b/api/views/social_view.py
@@ -87,7 +87,7 @@ class MemberViewSet(viewsets.ModelViewSet):
 
         return super().update(request, partial=True)
 
-    @action(detail=True, methods=["put"])
+    @action(detail=True, methods=["patch"])
     def approve(self, request, pk=None):
         """ approve the join request """
         try:
@@ -100,7 +100,7 @@ class MemberViewSet(viewsets.ModelViewSet):
         except Member.DoesNotExist:
             return Response({"msg": "failure"}, status.HTTP_404_NOT_FOUND)
 
-    @action(detail=True, methods=["put"])
+    @action(detail=True, methods=["patch"])
     def leave(self, request, pk=None):
         """ leave this team this is deletion but only to deactivate the record """
 

--- a/api/views/ticket_view.py
+++ b/api/views/ticket_view.py
@@ -16,7 +16,7 @@ from ..serializers import (
     TicketCommentSerializer,
     TicketStatusSerializer
 )
-from ..permissions import IsTicketOwnerOrReadOnly, IsAdminOrReadOnly
+from ..permissions import IsOwnerOrReadOnly, IsAdminMemberOrReadOnly
 
 
 class TicketViewSet(viewsets.ModelViewSet):
@@ -26,7 +26,7 @@ class TicketViewSet(viewsets.ModelViewSet):
 
     permission_classes = [
         permissions.IsAuthenticated,
-        IsTicketOwnerOrReadOnly
+        IsOwnerOrReadOnly
     ]
 
     queryset = Ticket.objects.all()
@@ -49,7 +49,7 @@ class TicketCommentViewSet(viewsets.ModelViewSet):
 
     permission_classes = [
         permissions.IsAuthenticated,
-        IsTicketOwnerOrReadOnly | IsAdminOrReadOnly,
+        IsOwnerOrReadOnly | IsAdminMemberOrReadOnly,
     ]
 
     queryset = TicketComment.objects.all()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 django-bulma==0.8.0
+dj-rest-auth

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-django-bulma==0.8.0
-dj-rest-auth
+django-bulma==0.8.0,
+dj-rest-auth[with_social]


### PR DESCRIPTION
Once again I am reminded that I need to make another branch. Maybe next time. Permissions are being revamped making use of the fact that most of our records will have a team reference somewhere.

Changes to permissions:
- IsTicketOwner was renamed to IsOwner. All tables that are semantically created by a user refer to that user as an owner.
- BaseMemberPermission is a class that should be used abstractly. It includes a convenience method for querying the member table for use in IsMember and IsAdminMember.
- Aforementioned IsMember and IsAdminMember query the member table to see if the request.user, team.id pair lead to a member record.

Permissions inheriting from BaseMemberPermission should only be used with tables that reference a team. These permissions calculate the member primary key from the team.id and username pair in order to retrieve a member record where the permission classes can do further processing.

MemberViewSet now inherits from mixins. This is so that the endpoints requiring the same level of permission are defined by the permission_classes. Endpoints that require a different set of permissions are defined with the `@action` decorator similar to bottle.
With these changes:

1. creation of member records requires only that the user is authenticated
2. reading member list / detailed record is only allowed for team members
3. approving members is only allowed for admins
4. updating the member profile is only allowed for the owner of that record
5. we are using a custom deactivate endpoint rather than a hard deletion

