### PR TITLE
Tdimhcsleumas/sprint

### DIFF
--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -3,3 +3,4 @@ from .team import Team
 from .ticket import Ticket
 from .ticket_comment import TicketComment
 from .ticket_status import TicketStatus
+from .ticket_tag import Tag, TicketTag

--- a/api/models/ticket.py
+++ b/api/models/ticket.py
@@ -33,12 +33,16 @@ class Ticket(models.Model):
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
         related_name="assigned_ticket",
+        null=True,
+        blank=True
     )
 
     status = models.ForeignKey(
         TicketStatus,
         on_delete=models.CASCADE,
-        related_name="status_ticket"
+        related_name="status_ticket",
+        blank=True,
+        null=True
     )
 
     title = models.CharField(max_length=100, blank=False)

--- a/api/models/ticket.py
+++ b/api/models/ticket.py
@@ -6,6 +6,22 @@ from .ticket_status import TicketStatus
 from .member import Member
 
 
+class TicketManager(models.Manager):
+    # this is a convenience class which handles defining the id before a save
+    # ( i think it gets automatically invoked on member instantiation before save)
+    def create(self, **obj_data):
+        team = obj_data.get("team")
+        owner = obj_data.get('owner')
+
+        if not owner or not team:
+            raise ValueError("missing name or team")
+
+        team.ticket_head += 1
+        team.save()
+        obj_data["ticket_number"] = team.ticket_head
+
+        return super().create(**obj_data)
+
 class Ticket(models.Model):
     """
     The Ticket class for Sluggo. This will store all information associated with a specific ticket.
@@ -50,6 +66,8 @@ class Ticket(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     activated = models.DateTimeField(null=True, blank=True)
     deactivated = models.DateTimeField(null=True, blank=True)
+
+    objects = TicketManager()
 
     class Meta:
         ordering = ["id"]

--- a/api/models/ticket.py
+++ b/api/models/ticket.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.conf import settings
 
 from .team import Team
+from .ticket_status import TicketStatus
 from .member import Member
 
 
@@ -32,6 +33,12 @@ class Ticket(models.Model):
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
         related_name="assigned_ticket",
+    )
+
+    status = models.ForeignKey(
+        TicketStatus,
+        on_delete=models.CASCADE,
+        related_name="status_ticket"
     )
 
     title = models.CharField(max_length=100, blank=False)

--- a/api/models/ticket_tag.py
+++ b/api/models/ticket_tag.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.conf import settings
 from .team import Team
 from .ticket import Ticket
+from hashlib import md5
 
 
 class Tag(models.Model):
@@ -20,6 +21,20 @@ class Tag(models.Model):
         return f"Tag: {self.title}"
 
 
+class TicketTagManager(models.Manager):
+    def create(self, **obj_data):
+        tag = obj_data.get("tag")
+        ticket = obj_data.get("ticket")
+
+        if not tag or not ticket:
+            raise ValueError("missing name or team")
+
+        team_id = "{}".format(tag.id)
+        ticket_id = "{}".format(ticket.id)
+        obj_data["id"] = md5(team_id.encode()).hexdigest() + md5(ticket_id.encode()).hexdigest()
+        return super().create(**obj_data)
+
+
 class TicketTag(models.Model):
     team = models.ForeignKey(Team, on_delete=models.CASCADE)
     tag = models.ForeignKey(Tag, on_delete=models.CASCADE)
@@ -27,6 +42,8 @@ class TicketTag(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     activated = models.DateTimeField(null=True, blank=True)
     deactivated = models.DateTimeField(null=True, blank=True)
+
+    objects = TicketTagManager()
 
     class Meta:
         ordering = ["id"]

--- a/api/models/ticket_tag.py
+++ b/api/models/ticket_tag.py
@@ -1,0 +1,36 @@
+# this here defines the ticket_tags
+from django.db import models
+from django.conf import settings
+from .team import Team
+from .ticket import Ticket
+
+
+class Tag(models.Model):
+    team = models.ForeignKey(Team, on_delete=models.CASCADE)
+    title = models.CharField(max_length=100, blank=False)
+    created = models.DateTimeField(auto_now_add=True)
+    activated = models.DateTimeField(null=True, blank=True)
+    deactivated = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        ordering = ["id"]
+        app_label = "api"
+
+    def __str__(self):
+        return f"Tag: {self.title}"
+
+
+class TicketTag(models.Model):
+    team = models.ForeignKey(Team, on_delete=models.CASCADE)
+    tag = models.ForeignKey(Tag, on_delete=models.CASCADE)
+    ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE)
+    created = models.DateTimeField(auto_now_add=True)
+    activated = models.DateTimeField(null=True, blank=True)
+    deactivated = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        ordering = ["id"]
+        app_label = "api"
+
+    def __str__(self):
+        return f"TicketTag: {self.created}"

--- a/api/models/ticket_tag.py
+++ b/api/models/ticket_tag.py
@@ -36,9 +36,10 @@ class TicketTagManager(models.Manager):
 
 
 class TicketTag(models.Model):
+    id = models.CharField(max_length=256, unique=True, editable=False, primary_key=True)
     team = models.ForeignKey(Team, on_delete=models.CASCADE)
     tag = models.ForeignKey(Tag, on_delete=models.CASCADE)
-    ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE)
+    ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE, related_name="tagged_ticket")
     created = models.DateTimeField(auto_now_add=True)
     activated = models.DateTimeField(null=True, blank=True)
     deactivated = models.DateTimeField(null=True, blank=True)
@@ -46,7 +47,7 @@ class TicketTag(models.Model):
     objects = TicketTagManager()
 
     class Meta:
-        ordering = ["id"]
+        ordering = ["created"]
         app_label = "api"
 
     def __str__(self):

--- a/api/models/ticket_tag.py
+++ b/api/models/ticket_tag.py
@@ -39,7 +39,7 @@ class TicketTag(models.Model):
     id = models.CharField(max_length=256, unique=True, editable=False, primary_key=True)
     team = models.ForeignKey(Team, on_delete=models.CASCADE)
     tag = models.ForeignKey(Tag, on_delete=models.CASCADE)
-    ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE)
+    ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE, related_name='tag_list')
     created = models.DateTimeField(auto_now_add=True)
     activated = models.DateTimeField(null=True, blank=True)
     deactivated = models.DateTimeField(null=True, blank=True)

--- a/api/models/ticket_tag.py
+++ b/api/models/ticket_tag.py
@@ -39,7 +39,7 @@ class TicketTag(models.Model):
     id = models.CharField(max_length=256, unique=True, editable=False, primary_key=True)
     team = models.ForeignKey(Team, on_delete=models.CASCADE)
     tag = models.ForeignKey(Tag, on_delete=models.CASCADE)
-    ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE, related_name="tagged_ticket")
+    ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE)
     created = models.DateTimeField(auto_now_add=True)
     activated = models.DateTimeField(null=True, blank=True)
     deactivated = models.DateTimeField(null=True, blank=True)

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -22,8 +22,8 @@ class BaseMemberPermissions(permissions.BasePermission):
 class IsMemberUser(BaseMemberPermissions):
     def has_object_permission(self, request, view, obj):
         try:
-            self.retrieveMemberRecord(request.user.username, obj.team.id)
-            permit = Member.Roles.APPROVED
+            member_record = self.retrieveMemberRecord(request.user.username, obj.team.id)
+            permit = member_record.role == Member.Roles.APPROVED
         except Member.DoesNotExist:
             permit = False
 

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -9,7 +9,9 @@ these all need to be deprecated as they are reliant on the old profile
 
 class BaseMemberPermissions(permissions.BasePermission):
     # this will throw a member not found exception
-    def retrieveMemberRecord(self, username, team_id):
+
+    def retrieveMemberRecord(self, username, obj):
+        team_id = obj.id if isinstance(obj, Team) else obj.team.id
         team_id = "{}".format(team_id)
         member_pk = (
             md5(team_id.encode()).hexdigest() + md5(username.encode()).hexdigest()
@@ -21,9 +23,10 @@ class BaseMemberPermissions(permissions.BasePermission):
 # only permit this if the user is approved
 class IsMemberUser(BaseMemberPermissions):
     def has_object_permission(self, request, view, obj):
+
         try:
-            member_record = self.retrieveMemberRecord(request.user.username, obj.team.id)
-            permit = member_record.role == Member.Roles.APPROVED
+            member_record = self.retrieveMemberRecord(request.user.username, obj)
+            permit = member_record.role != Member.Roles.UNAPPROVED
         except Member.DoesNotExist:
             permit = False
 
@@ -38,14 +41,12 @@ class IsAdminMemberOrReadOnly(BaseMemberPermissions):
     def has_object_permission(self, request, view, obj):
         # Read permissions are allowed to any request,
         # so we'll always allow GET, HEAD or OPTIONS requests.
-        team_id = obj.id if isinstance(obj, Team) else obj.team.id
-
         if request.method not in permissions.SAFE_METHODS:
             try:
                 # Write permissions are only allowed to the owner of the object, or admin.
 
                 member_record = self.retrieveMemberRecord(
-                    request.user.username, team_id
+                    request.user.username, obj
                 )
                 permit = member_record.role == Member.Roles.ADMIN
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -126,11 +126,14 @@ class TicketStatusSerializer(serializers.ModelSerializer):
 class TicketTagSerializer(serializers.ModelSerializer):
     team_id = serializers.ReadOnlyField(source="team.id")
     tag = TagSerializer(many=False, read_only=True)
+    ticket_id = serializers.ReadOnlyField(source="ticket.id")
     created = serializers.ReadOnlyField()
+    activated = serializers.ReadOnlyField()
+    deactivated = serializers.ReadOnlyField()
 
     class Meta:
         model = api_models.TicketTag
-        fields = ["tag"]
+        fields = ["id", "team_id", "tag", "ticket_id", "created", "activated", "deactivated"]
 
 
 class TicketSerializer(serializers.ModelSerializer):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -39,6 +39,20 @@ class TeamSerializer(serializers.ModelSerializer):
         ]
 
 
+class TagSerializer(serializers.ModelSerializer):
+    id = serializers.ReadOnlyField
+    team_id = serializers.PrimaryKeyRelatedField(
+        many=False, read_only=False, queryset=api_models.Team.objects.all()
+    )
+    created = serializers.ReadOnlyField
+    activated = serializers.ReadOnlyField
+    deactivated = serializers.ReadOnlyField
+
+    class Meta:
+        model = api_models.Tag
+        fields = ["id", "team_id", "title", "created", "activated", "deactivated"]
+
+
 class MemberSerializer(serializers.ModelSerializer):
     id = serializers.ReadOnlyField()
     owner = UserSerializer(many=False, read_only=True)
@@ -180,5 +194,6 @@ class TicketSerializer(serializers.ModelSerializer):
         instance.assigned_user = assigned_user
         instance.status = status
         return super().update(instance, validated_data)
+
 
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -19,7 +19,6 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class TeamSerializer(serializers.ModelSerializer):
-
     # make the following fields read only
     id = serializers.ReadOnlyField()
     ticket_head = serializers.ReadOnlyField()
@@ -86,6 +85,14 @@ class TicketCommentSerializer(serializers.ModelSerializer):
         ]
 
 
+class TicketStatusSerializer(serializers.ModelSerializer):
+    team_id = serializers.ReadOnlyField(source="team.id")
+
+    class Meta:
+        model = api_models.TicketStatus
+        fields = ["id", "team_id", "title", "created", "activated", "deactivated"]
+
+
 class TicketSerializer(serializers.ModelSerializer):
     """
     Serializer Class for the Ticket model.
@@ -108,6 +115,7 @@ class TicketSerializer(serializers.ModelSerializer):
     owner = UserSerializer(many=False, read_only=True)
     comments = TicketCommentSerializer(many=True, required=False)
     assigned_user = UserSerializer(many=False, read_only=True)
+    status = TicketStatusSerializer(many=False, read_only=True)
     created = serializers.ReadOnlyField()
     activated = serializers.ReadOnlyField()
     deactivated = serializers.ReadOnlyField()
@@ -120,6 +128,7 @@ class TicketSerializer(serializers.ModelSerializer):
             "ticket_number",
             "owner",
             "assigned_user",
+            "status",
             "title",
             "description",
             "comments",
@@ -127,11 +136,3 @@ class TicketSerializer(serializers.ModelSerializer):
             "activated",
             "deactivated",
         ]
-
-
-class TicketStatusSerializer(serializers.ModelSerializer):
-    team_id = serializers.ReadOnlyField(source="team.id")
-
-    class Meta:
-        model = api_models.TicketStatus
-        fields = ["id", "team_id", "title", "created", "activated", "deactivated"]

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -172,8 +172,6 @@ class TicketSerializer(serializers.ModelSerializer):
         assigned_user, status = self.parse_fields(validated_data)
         instance.assigned_user = assigned_user
         instance.status = status
-        instance.save()
-
-        return instance
+        return super().update(instance, validated_data)
 
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -124,16 +124,14 @@ class TicketStatusSerializer(serializers.ModelSerializer):
 
 
 class TicketTagSerializer(serializers.ModelSerializer):
-    team_id = serializers.ReadOnlyField(source="team.id")
     tag = TagSerializer(many=False, read_only=True)
-    ticket_id = serializers.ReadOnlyField(source="ticket.id")
     created = serializers.ReadOnlyField()
     activated = serializers.ReadOnlyField()
     deactivated = serializers.ReadOnlyField()
 
     class Meta:
         model = api_models.TicketTag
-        fields = ["id", "team_id", "tag", "ticket_id", "created", "activated", "deactivated"]
+        fields = ["tag", "created", "activated", "deactivated"]
 
 
 class TicketSerializer(serializers.ModelSerializer):
@@ -220,5 +218,5 @@ class TicketSerializer(serializers.ModelSerializer):
     def update(self, instance, validated_data):
         validated_data['status'] = validated_data.pop('status_id', None)
         validated_data['assigned_user'] = validated_data.pop('assigned_user_id', None)
-        validated_data.pop('tag_list_id')
+        validated_data.pop('tag_id_list', None)
         return super().update(instance, validated_data)

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -86,11 +86,18 @@ class TicketCommentSerializer(serializers.ModelSerializer):
 
 
 class TicketStatusSerializer(serializers.ModelSerializer):
-    team_id = serializers.ReadOnlyField(source="team.id")
+    team_id = serializers.PrimaryKeyRelatedField(
+        many=False, read_only=False, queryset=api_models.Team.objects.all()
+    )
 
     class Meta:
         model = api_models.TicketStatus
         fields = ["id", "team_id", "title", "created", "activated", "deactivated"]
+
+    def create(self, validated_data):
+        validated_data['team'] = validated_data.pop('team_id')
+        status = api_models.TicketStatus.objects.create(**validated_data)
+        return status
 
 
 class TicketSerializer(serializers.ModelSerializer):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -40,13 +40,13 @@ class TeamSerializer(serializers.ModelSerializer):
 
 
 class TagSerializer(serializers.ModelSerializer):
-    id = serializers.ReadOnlyField
+    id = serializers.ReadOnlyField()
     team_id = serializers.PrimaryKeyRelatedField(
         many=False, read_only=False, queryset=api_models.Team.objects.all()
     )
-    created = serializers.ReadOnlyField
-    activated = serializers.ReadOnlyField
-    deactivated = serializers.ReadOnlyField
+    created = serializers.ReadOnlyField()
+    activated = serializers.ReadOnlyField()
+    deactivated = serializers.ReadOnlyField()
 
     class Meta:
         model = api_models.Tag

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -52,6 +52,15 @@ class TagSerializer(serializers.ModelSerializer):
         model = api_models.Tag
         fields = ["id", "team_id", "title", "created", "activated", "deactivated"]
 
+    def create(self, validated_data):
+
+        validated_data['team'] = validated_data.pop('team_id')
+
+        tag = api_models.Tag.objects.create(
+            **validated_data
+        )
+        return tag
+
 
 class MemberSerializer(serializers.ModelSerializer):
     id = serializers.ReadOnlyField()
@@ -194,6 +203,3 @@ class TicketSerializer(serializers.ModelSerializer):
         instance.assigned_user = assigned_user
         instance.status = status
         return super().update(instance, validated_data)
-
-
-

--- a/api/settings.py
+++ b/api/settings.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
     'allauth.account',
     'allauth.socialaccount',
     'dj_rest_auth.registration',
+    'django_filters'
 ]
 
 REST_SESSION_LOGIN = True
@@ -116,6 +117,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.TokenAuthentication',
     ),
+    'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend'],
     'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 10,

--- a/api/tests/ticket_test.py
+++ b/api/tests/ticket_test.py
@@ -6,9 +6,9 @@ from django.urls import reverse
 
 from ..models import Ticket
 from ..models import Member
-from ..models import Team, Member, Tag, TicketStatus
+from ..models import Team, Member, Tag, TicketStatus, TicketTag
 from ..views import TicketViewSet
-from ..serializers import UserSerializer, TicketStatusSerializer
+from ..serializers import UserSerializer, TicketStatusSerializer, TicketTagSerializer
 
 import datetime
 
@@ -405,8 +405,17 @@ class TagViewTestCase(TestCase):
             ticket_data,
             format="json"
         )
-        print(response.data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        ticket_tag = TicketTag.objects.get(team=self.team)
+
+        self.ticket = Ticket.objects.get(pk=response.data["id"])
+        response = self.ticket_client.get(
+            reverse("ticket-detail", kwargs={"pk": self.ticket.id}),
+            format="json"
+        )
+        print(response.data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 
 class StatusViewTestCase(TestCase):

--- a/api/tests/ticket_test.py
+++ b/api/tests/ticket_test.py
@@ -145,8 +145,8 @@ class TicketViewTestCase(TestCase):
             "team_id": self.team.id,
         }
 
-        self.reponse = None
-        for i in range(0,2):
+        self.response = None
+        for i in range(1):
             self.response = self.ticket_client.post(
                 reverse("ticket-create-record"), self.ticket_data, format="json"
             )
@@ -201,7 +201,7 @@ class TicketViewTestCase(TestCase):
         # change the record's values. this call should return the newly updated record
         new_data = {
             "title": "Erit Lux",
-            "ticket_number": 2,
+            "team_id": self.team.id
         }
 
         response = self.ticket_client.put(
@@ -209,6 +209,8 @@ class TicketViewTestCase(TestCase):
             new_data,
             format="json",
         )
+
+        print(response.data)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/api/tests/ticket_test.py
+++ b/api/tests/ticket_test.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from ..models import Ticket
 from ..models import Member
 from ..models import Team, Member, Tag, TicketStatus, TicketTag
-from ..views import TicketViewSet
+from ..views import TicketViewSet, TicketTagViewSet
 from ..serializers import UserSerializer, TicketStatusSerializer, TicketTagSerializer
 
 import datetime
@@ -416,6 +416,14 @@ class TagViewTestCase(TestCase):
         )
         print(response.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+        #response = self.ticket_client.get(
+        #    reverse("tickettag-fetch-ticket", kwargs={"pk": self.ticket.id}),
+        #    format="json"
+        #)
+        #print(response.data)
+        #self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 
 class StatusViewTestCase(TestCase):

--- a/api/tests/ticket_test.py
+++ b/api/tests/ticket_test.py
@@ -105,8 +105,6 @@ class TicketViewTestCase(TestCase):
         self.admin_user = User.objects.create_user(**admin_dict)
         self.admin_user.save()
 
-
-
         self.ticket_client = APIClient()
         self.ticket_client.force_authenticate(user=self.ticket_user)
         mem_response = self.ticket_client.post(
@@ -140,17 +138,19 @@ class TicketViewTestCase(TestCase):
         self.ticket_data = {
             "assigned_id": self.assigned_user.id,
             "title": "Sic Mundus Creatus Est",
-            "ticket_number": 1,
             "team_id": self.team.id,
         }
         self.ticket_get_data = {
             "title": "Sic Mundus Creatus Est",
-            "ticket_number": 1,
             "team_id": self.team.id,
         }
-        self.response = self.ticket_client.post(
-            reverse("ticket-create-record"), self.ticket_data, format="json"
-        )
+
+        self.reponse = None
+        for i in range(0,2):
+            self.response = self.ticket_client.post(
+                reverse("ticket-create-record"), self.ticket_data, format="json"
+            )
+
 
         self.ticket_id = self.response.data["id"]
 
@@ -170,15 +170,23 @@ class TicketViewTestCase(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        print(response.data)
-
-        for k, v in self.ticket_get_data.items():
-            self.assertEqual(v, response.data.get(k))
-
     def testTicketList(self):
         # eat shit and die
+
+        self.another_ticket = {
+            "title": "Ticket",
+            "description": "Fix the toaster",
+           "team_id": self.team.id,
+        }
+
+        self.ticket_client.post(
+            reverse("ticket-create-record"),
+            self.another_ticket,
+            format="json"
+        )
+
         url = reverse('ticket-list-team', kwargs={"pk": self.team.id})
-        url += '?search=Hanno'
+        url += '?ordering=-created'
 
         print(url)
 
@@ -188,7 +196,6 @@ class TicketViewTestCase(TestCase):
         print(response.data)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-
 
     def testTicketUpdate(self):
         # change the record's values. this call should return the newly updated record

--- a/api/tests/ticket_test.py
+++ b/api/tests/ticket_test.py
@@ -11,7 +11,6 @@ from ..views import TicketViewSet
 
 import datetime
 
-
 User = get_user_model()
 
 assigned_dict = dict(
@@ -161,14 +160,27 @@ class TicketViewTestCase(TestCase):
 
     def testTicketRead(self):
         # read the record created in setUp. confirm the results are expected
+        url = reverse("ticket-detail", kwargs={"pk": self.ticket_id})
+        print(url)
         response = self.ticket_client.get(
-            reverse("ticket-detail", kwargs={"pk": self.ticket_id}), format="json"
+            url, format="json"
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         for k, v in self.ticket_get_data.items():
             self.assertEqual(v, response.data.get(k))
+
+    def testTicketList(self):
+        # eat shit and die
+        url = reverse('ticket-list-team', kwargs={"pk": 1})
+        response = self.ticket_client.get(
+            url, format="json"
+        )
+        print(response.data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
 
     def testTicketUpdate(self):
         # change the record's values. this call should return the newly updated record
@@ -309,4 +321,3 @@ class TicketViewTestCase(TestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-

--- a/api/tests/ticket_test.py
+++ b/api/tests/ticket_test.py
@@ -8,6 +8,7 @@ from ..models import Ticket
 from ..models import Member
 from ..models import Team, Member, Tag, TicketStatus
 from ..views import TicketViewSet
+from ..serializers import UserSerializer, TicketStatusSerializer
 
 import datetime
 
@@ -419,8 +420,15 @@ class StatusViewTestCase(TestCase):
         response = self.ticket_client.get(
             reverse("ticketstatus-detail", kwargs={"pk": self.status.id}), format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
         print(response.data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def testList(self):
+        response = self.ticket_client.get(
+            reverse("ticketstatus-list-team", kwargs={"pk": self.team.id}), format="json"
+        )
+        print(response.data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def testUpdate(self):
         status_dict = {
@@ -433,7 +441,6 @@ class StatusViewTestCase(TestCase):
             status_dict,
             format="json"
         )
-        print(response.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def testDelete(self):
@@ -441,5 +448,20 @@ class StatusViewTestCase(TestCase):
             reverse("ticketstatus-detail", kwargs={"pk": self.status.id}),
             format="json"
         )
-        print(response.data)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def testTicket(self):
+        serialized = TicketStatusSerializer(self.status)
+        ticket_data = {
+            "title": "Sic Mundus Creatus Est",
+            "team_id": self.team.id,
+            "status_id": self.status.id
+        }
+        print(ticket_data)
+        response = self.ticket_client.post(
+            reverse("ticket-create-record"),
+            ticket_data,
+            format="json"
+        )
+        print(response.data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/api/tests/ticket_test.py
+++ b/api/tests/ticket_test.py
@@ -392,6 +392,22 @@ class TagViewTestCase(TestCase):
         print(response.data)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
+    def testTicket(self):
+        ticket_data = {
+            "title": "Sic Mundus Creatus Est",
+            "team_id": self.team.id,
+            "tag_id_list": [
+                self.tag.id,
+            ]
+        }
+        response = self.ticket_client.post(
+            reverse("ticket-create-record"),
+            ticket_data,
+            format="json"
+        )
+        print(response.data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
 
 class StatusViewTestCase(TestCase):
     def setUp(self):

--- a/api/urls.py
+++ b/api/urls.py
@@ -2,6 +2,7 @@
 This project will house Andrew's testing of REST API things
 """
 from django.urls import include, path
+from django.contrib import admin
 from rest_framework.routers import DefaultRouter
 from . import views as api_views
 
@@ -29,5 +30,6 @@ urlpatterns = [
     path('dj-rest-auth/registration', include('dj_rest_auth.registration.urls')),
 
     path("api-auth/", include("rest_framework.urls")),
+    path('admin/', admin.site.urls)
 ]
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -11,8 +11,6 @@ router = DefaultRouter()
 # social stuff
 router.register(r"member", api_views.MemberViewSet)
 router.register(r"team", api_views.TeamViewSet)
-router.register(r"status", api_views.TicketStatusViewSet)
-router.register(r"tag", api_views.TagViewSet)
 
 team_search = api_views.TeamViewSet.as_view({
     'get': 'search'
@@ -21,8 +19,8 @@ team_search = api_views.TeamViewSet.as_view({
 # ticket stuff
 router.register(r"ticket", api_views.TicketViewSet)
 router.register(r"ticket-comment", api_views.TicketCommentViewSet)
-router.register(r"ticket-status", api_views.TicketStatusViewSet)
-
+router.register(r"status", api_views.TicketStatusViewSet)
+router.register(r"tag", api_views.TagViewSet)
 
 urlpatterns = [
     path("", include(router.urls)),
@@ -34,4 +32,3 @@ urlpatterns = [
     path("api-auth/", include("rest_framework.urls")),
     path('admin/', admin.site.urls)
 ]
-

--- a/api/urls.py
+++ b/api/urls.py
@@ -11,6 +11,8 @@ router = DefaultRouter()
 # social stuff
 router.register(r"member", api_views.MemberViewSet)
 router.register(r"team", api_views.TeamViewSet)
+router.register(r"status", api_views.TicketStatusViewSet)
+router.register(r"tag", api_views.TagViewSet)
 
 team_search = api_views.TeamViewSet.as_view({
     'get': 'search'

--- a/api/urls.py
+++ b/api/urls.py
@@ -20,6 +20,7 @@ team_search = api_views.TeamViewSet.as_view({
 router.register(r"ticket", api_views.TicketViewSet)
 router.register(r"ticket-comment", api_views.TicketCommentViewSet)
 router.register(r"status", api_views.TicketStatusViewSet)
+router.register(r"ticket-tag", api_views.TicketTagViewSet)
 router.register(r"tag", api_views.TagViewSet)
 
 urlpatterns = [

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -1,2 +1,2 @@
 from .social_view import MemberViewSet, TeamViewSet
-from .ticket_view import TicketViewSet, TicketCommentViewSet, TicketStatusViewSet
+from .ticket_view import TicketViewSet, TicketCommentViewSet, TicketStatusViewSet, TagViewSet

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -1,2 +1,2 @@
 from .social_view import MemberViewSet, TeamViewSet
-from .ticket_view import TicketViewSet, TicketCommentViewSet, TicketStatusViewSet, TagViewSet
+from .ticket_view import TicketViewSet, TicketCommentViewSet, TicketStatusViewSet, TagViewSet, TicketTagViewSet

--- a/api/views/ticket_view.py
+++ b/api/views/ticket_view.py
@@ -119,6 +119,14 @@ class TicketViewSet(
         except serializers.ValidationError as e:
             return Response({"msg": e.detail}, e.status_code)
 
+    # note: this is pretty hacky
+    def update(self, request, *args, **kwargs):
+        super().update(request, *args, **kwargs)
+        instance = self.get_object()
+        serializer = TicketSerializer(instance)
+        return Response(serializer.data)
+
+
     @action(
         detail=True,
         methods=['patch'],

--- a/api/views/ticket_view.py
+++ b/api/views/ticket_view.py
@@ -209,9 +209,9 @@ class TicketStatusViewSet(
 
             # make sure we're actually allowed to access this team
             self.check_object_permissions(request, team)
-            status = serializer.save()
+            status_record = serializer.save()
 
-            serialized = TicketStatusSerializer(status)
+            serialized = TicketStatusSerializer(status_record)
             return Response(serialized.data, status.HTTP_201_CREATED)
 
         except serializers.ValidationError as e:
@@ -260,7 +260,20 @@ class TagViewSet(
         methods=["POST"], detail=False, permission_classes=[permissions.IsAuthenticated, IsMemberUser]
     )
     def create_record(self, request, *args, **kwargs):
-        pass
+        try:
+            serializer = TagSerializer(data=request.data)
+            serializer.is_valid(raise_exception=True)
+            team = serializer.validated_data["team_id"]
+
+            # make sure we're actually allowed to access this team
+            self.check_object_permissions(request, team)
+            status_record = serializer.save()
+
+            serialized = TagSerializer(status_record)
+            return Response(serialized.data, status.HTTP_201_CREATED)
+
+        except serializers.ValidationError as e:
+            return Response({"msg": e.detail}, e.status_code)
 
     @action(detail=True, methods=["GET"], permission_classes=permission_classes)
     def list_team(self, request, pk=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 dj-rest-auth[with_social]
+django-filter


### PR DESCRIPTION
Tickets are nearly there! With the exception of subtickets, everything should be complete.

What's been added:
- Tickets may specify a list of tag_id's which correlate to existing tag record
- Likewise, tickets may specify the id of a preexisting status.

I cleaned some of the code up in ticket_view, making use of more complicated serializer functionality.