### PR TITLE
Admin Dashboard Updates

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -1,29 +1,87 @@
 from django.contrib import admin
 from .models import (Ticket, Member, Team, TicketComment, TicketStatus,
-                     TicketNode, TicketTag, Event)
+                     TicketNode, TicketTag, Event, Tag)
 
 
-@admin.register(Ticket)
-class TicketAdmin(admin.ModelAdmin):
-    readonly_fields = ("created", "ticket_number")
-
-
-@admin.register(Member)
-class MemberAdmin(admin.ModelAdmin):
-    readonly_fields = ("created", )
+# Custom Admin class that will allow you to mark fields to be readonly on edits.
+class customAdmin(admin.ModelAdmin):
+    readonly_edit = tuple()
 
     def get_readonly_fields(self, request, obj=None):
         if obj:  # Make team and owner readonly ONLY when the object already exists
-            return self.readonly_fields + ("team", "owner")
+            return self.readonly_fields + self.readonly_edit
         return self.readonly_fields
 
-    fields = ("team", "owner", "role", "pronouns", "bio")
+
+@admin.register(Event)
+class EventAdmin(customAdmin):
+    readonly_fields = ("object", "id")
+    readonly_edit = ("team", )
+
+    fields = ("id", "team", "event_type", "description", "user")
 
 
-# Register your models here.
-admin.site.register(Team)
-admin.site.register(TicketComment)
-admin.site.register(TicketStatus)
-admin.site.register(TicketNode)
-admin.site.register(TicketTag)
-admin.site.register(Event)
+@admin.register(Member)
+class MemberAdmin(customAdmin):
+    readonly_fields = ("created", "id")
+    readonly_edit = ("team", "owner")
+
+    fields = ("id", "team", "owner", "role", "pronouns", "bio", "created",
+              "activated", "deactivated")
+
+
+@admin.register(Tag)
+class TagAdmin(customAdmin):
+    readonly_fields = ("team_title_hash", "id", "created")
+
+    fields = ("id", "team", "title", "created", "activated", "deactivated",
+              "team_title_hash")
+
+
+@admin.register(Team)
+class TeamAdmin(customAdmin):
+    readonly_fields = ("created", "ticket_head", "id")
+
+    fields = (("id", "ticket_head"), "name", "description", "created",
+              "activated", "deactivated")
+
+
+@admin.register(TicketComment)
+class TicketCommentAdmin(customAdmin):
+    readonly_fields = ("created", "id")
+    readonly_edit = ("ticket", "team")
+
+    fields = ("id", "team", "ticket", "owner", "content", "created",
+              "activated", "deactivated")
+
+
+@admin.register(TicketNode)
+class TicketNodeAdmin(customAdmin):
+    readonly_fields = ("id", )
+
+
+@admin.register(TicketStatus)
+class TicketStatusAdmin(customAdmin):
+    readonly_fields = ("created", "id")
+    readonly_edit = ("team", )
+
+    fields = ("id", "team", "title", "created", "activated", "deactivated")
+
+
+@admin.register(TicketTag)
+class TicketTagAdmin(customAdmin):
+    readonly_fields = ("created", "id")
+    readonly_edit = ("team", )
+
+    fields = ("id", "team", "tag", "ticket", "created", "activated",
+              "deactivated")
+
+
+@admin.register(Ticket)
+class TicketAdmin(customAdmin):
+    readonly_fields = ("created", "ticket_number", "id", "activated")
+    readonly_edit = ("team", )
+
+    fields = ("id", "ticket_number", "team", "owner", "assigned_user",
+              "status", "title", "description", "created", "activated",
+              "deactivated")

--- a/api/admin.py
+++ b/api/admin.py
@@ -5,7 +5,7 @@ from .models import (Ticket, Member, Team, TicketComment, TicketStatus,
 
 @admin.register(Ticket)
 class TicketAdmin(admin.ModelAdmin):
-    readonly_fields = ("created", )
+    readonly_fields = ("created", "ticket_number")
 
 
 @admin.register(Member)

--- a/api/admin.py
+++ b/api/admin.py
@@ -1,16 +1,26 @@
 from django.contrib import admin
-from .models import (
-    Ticket, Member, Team, TicketComment, TicketStatus, TicketNode, TicketTag, Event
-)
+from .models import (Ticket, Member, Team, TicketComment, TicketStatus,
+                     TicketNode, TicketTag, Event)
 
 
+@admin.register(Ticket)
 class TicketAdmin(admin.ModelAdmin):
-    readonly_fields = ("created",)
+    readonly_fields = ("created", )
+
+
+@admin.register(Member)
+class MemberAdmin(admin.ModelAdmin):
+    readonly_fields = ("created", )
+
+    def get_readonly_fields(self, request, obj=None):
+        if obj:  # Make team and owner readonly ONLY when the object already exists
+            return self.readonly_fields + ("team", "owner")
+        return self.readonly_fields
+
+    fields = ("team", "owner", "role", "pronouns", "bio")
 
 
 # Register your models here.
-admin.site.register(Ticket, TicketAdmin)
-admin.site.register(Member)
 admin.site.register(Team)
 admin.site.register(TicketComment)
 admin.site.register(TicketStatus)

--- a/api/models/event.py
+++ b/api/models/event.py
@@ -3,8 +3,10 @@ from .team import Team
 from django.conf import settings
 import uuid
 
+from api.models.interfaces import HasUuid, TeamRelated
 
-class Event(models.Model):
+
+class Event(TeamRelated):
     CREATE = 1
     UPDATE = 2
     DELETE = 3
@@ -15,11 +17,13 @@ class Event(models.Model):
         (DELETE, "Delete"),
     ]
 
-    team = models.ForeignKey(Team, on_delete=models.SET_NULL, null=True)
     created = models.DateTimeField(auto_now_add=True)
     event_type = models.SmallIntegerField(choices=events)
     description = models.TextField(null=True, blank=True)
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True, on_delete=models.SET_NULL)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL,
+                             null=True,
+                             blank=True,
+                             on_delete=models.SET_NULL)
     object = models.UUIDField(null=True, blank=False, default=uuid.uuid4)
 
     def is_create(self):

--- a/api/models/interfaces/team_related.py
+++ b/api/models/interfaces/team_related.py
@@ -3,9 +3,10 @@ from ..team import Team
 
 
 class TeamRelated(models.Model):
-    team = models.ForeignKey(
-        Team, on_delete=models.CASCADE, editable=False, null=False
-    )
+    team = models.ForeignKey(Team,
+                             on_delete=models.CASCADE,
+                             editable=True,
+                             null=False)
 
     class Meta:
         app_label = "api"

--- a/api/models/member.py
+++ b/api/models/member.py
@@ -59,11 +59,6 @@ class Member(HasUuid, TeamRelated):
     created = models.DateTimeField(auto_now_add=True)
     activated = models.DateTimeField(null=True, blank=True)
     deactivated = models.DateTimeField(null=True, blank=True)
-    memberUUID = models.UUIDField(null=True,
-                                  blank=False,
-                                  default=uuid.uuid4,
-                                  editable=False,
-                                  unique=True)
 
     def is_admin(self):
         return self.role == self.Roles.ADMIN

--- a/api/models/member.py
+++ b/api/models/member.py
@@ -23,7 +23,8 @@ class MemberManager(models.Manager):
         # id will be an md5 of the team.id formatted as a string, followed by the md5 of the username
 
         team_id = "{}".format(team.id)
-        obj_data["id"] = md5(team_id.encode()).hexdigest() + md5(owner.username.encode()).hexdigest()
+        obj_data["id"] = md5(team_id.encode()).hexdigest() + md5(
+            owner.username.encode()).hexdigest()
         return super().create(**obj_data)
 
 
@@ -41,7 +42,6 @@ class Member(HasUuid, TeamRelated):
         completed: A field to record when a ticket has been finished. (Datetime as well)
         due_date: The due date for the ticket, a date field that will keep track of when things are due.
     """
-
     class Roles(models.TextChoices):
         """
         A private class containing 3 options for Roles stored in multiple versions. A full name, "pretty" name, and 2-letter representation.
@@ -57,15 +57,18 @@ class Member(HasUuid, TeamRelated):
         ADMIN = "AD", _("Admin")
 
     # team.team_id + md5 (user.username)
-    id = models.CharField(max_length=256, unique=True, editable=False, primary_key=True)
+    id = models.CharField(max_length=256,
+                          unique=True,
+                          editable=False,
+                          primary_key=True)
 
-    owner = models.ForeignKey(
-        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, editable=False
-    )
+    owner = models.ForeignKey(settings.AUTH_USER_MODEL,
+                              on_delete=models.CASCADE,
+                              editable=True)
 
-    role = models.CharField(
-        max_length=2, choices=Roles.choices, default=Roles.UNAPPROVED
-    )
+    role = models.CharField(max_length=2,
+                            choices=Roles.choices,
+                            default=Roles.UNAPPROVED)
 
     pronouns = models.CharField(max_length=256, null=True)
 
@@ -73,7 +76,11 @@ class Member(HasUuid, TeamRelated):
     created = models.DateTimeField(auto_now_add=True)
     activated = models.DateTimeField(null=True, blank=True)
     deactivated = models.DateTimeField(null=True, blank=True)
-    memberUUID = models.UUIDField(null=True, blank=False, default=uuid.uuid4, editable=False, unique=True)
+    memberUUID = models.UUIDField(null=True,
+                                  blank=False,
+                                  default=uuid.uuid4,
+                                  editable=False,
+                                  unique=True)
 
     objects = MemberManager()
 
@@ -82,7 +89,6 @@ class Member(HasUuid, TeamRelated):
 
     def is_approved(self):
         return self.role == self.Roles.ADMIN or self.role == self.Roles.APPROVED
-
 
     class Meta:
         ordering = ["created"]

--- a/api/models/ticket.py
+++ b/api/models/ticket.py
@@ -7,26 +7,6 @@ from api.models.interfaces import HasUuid, TeamRelated
 import uuid
 
 
-class TicketManager(models.Manager):
-    """
-    Implements create method in order to set the ticket_number
-    based on the team's count
-    """
-
-    def create(self, **obj_data):
-        team = obj_data.get("team")
-        owner = obj_data.get('owner')
-
-        if not owner or not team:
-            raise ValueError("missing owner or team")
-
-        team.ticket_head += 1
-        team.save()
-        obj_data["ticket_number"] = team.ticket_head
-
-        return super().create(**obj_data)
-
-
 class Ticket(HasUuid, TeamRelated):
     """
     The Ticket class for Sluggo. This will store all information associated with a specific ticket.
@@ -45,25 +25,22 @@ class Ticket(HasUuid, TeamRelated):
 
     ticket_number = models.IntegerField()
 
-    owner = models.ForeignKey(
-        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="owned_ticket", null=False
-    )
+    owner = models.ForeignKey(settings.AUTH_USER_MODEL,
+                              on_delete=models.CASCADE,
+                              related_name="owned_ticket",
+                              null=False)
 
-    assigned_user = models.ForeignKey(
-        settings.AUTH_USER_MODEL,
-        on_delete=models.CASCADE,
-        related_name="assigned_ticket",
-        null=True,
-        blank=True
-    )
+    assigned_user = models.ForeignKey(settings.AUTH_USER_MODEL,
+                                      on_delete=models.CASCADE,
+                                      related_name="assigned_ticket",
+                                      null=True,
+                                      blank=True)
 
-    status = models.ForeignKey(
-        TicketStatus,
-        on_delete=models.CASCADE,
-        related_name="status_ticket",
-        blank=True,
-        null=True
-    )
+    status = models.ForeignKey(TicketStatus,
+                               on_delete=models.CASCADE,
+                               related_name="status_ticket",
+                               blank=True,
+                               null=True)
 
     tag_list = models.ManyToManyField('Tag', through='TicketTag')
 
@@ -73,8 +50,6 @@ class Ticket(HasUuid, TeamRelated):
     activated = models.DateTimeField(auto_now_add=True)
     deactivated = models.DateTimeField(null=True, blank=True)
 
-    objects = TicketManager()
-
     class Meta:
         ordering = ["id"]
         app_label = "api"
@@ -83,8 +58,24 @@ class Ticket(HasUuid, TeamRelated):
     def retrieve_by_user(cls, user: settings.AUTH_USER_MODEL, team: Team):
         return cls.objects.filter(
             models.Q(team=team), models.Q(deactivated=None),
-            models.Q(owner=user) | models.Q(assigned_user=user)
-        )
+            models.Q(owner=user) | models.Q(assigned_user=user))
 
     def __str__(self):
         return f"Ticket: {self.title}"
+
+    def save(self, *args, **kwargs):
+        team = self.team
+        owner = self.owner
+
+        if not owner:
+            raise ValueError("missing owner")
+
+        if not team:
+            raise ValueError("missing team")
+
+        # id will be an md5 of the team.id formatted as a string, followed by the md5 of the username
+        team.ticket_head += 1
+        team.save()
+        self.ticket_number = team.ticket_head
+
+        super(Ticket, self).save(*args, **kwargs)

--- a/api/models/ticket_tag.py
+++ b/api/models/ticket_tag.py
@@ -7,27 +7,14 @@ from api.models.interfaces import HasUuid, TeamRelated
 from hashlib import md5
 
 
-class TagManager(models.Manager):
-    def create(self, **obj_data):
-        title = obj_data.get("title")
-        team = obj_data.get("team")
-
-        if not title or not team:
-            raise ValueError("missing title or team")
-
-        title_id = "{}".format(title)
-        team_id = "{}".format(team.id)
-        obj_data["team_title_hash"] = md5(title_id.encode()).hexdigest() + md5(team_id.encode()).hexdigest()
-        return super().create(**obj_data)
-
-
 class Tag(HasUuid, TeamRelated):
-    team_title_hash = models.CharField(max_length=256, unique=True, editable=False)
+    team_title_hash = models.CharField(max_length=256,
+                                       unique=True,
+                                       editable=False)
     title = models.CharField(max_length=100, blank=False)
     created = models.DateTimeField(auto_now_add=True)
     activated = models.DateTimeField(null=True, blank=True)
     deactivated = models.DateTimeField(null=True, blank=True)
-    objects = TagManager()
 
     class Meta:
         ordering = ["id"]
@@ -36,29 +23,34 @@ class Tag(HasUuid, TeamRelated):
     def __str__(self):
         return f"Tag: {self.title}"
 
+    def save(self, *args, **kwargs):
+        team = self.team
+        title = self.title
 
-class TicketTagManager(models.Manager):
-    def create(self, **obj_data):
-        tag = obj_data.get("tag")
-        ticket = obj_data.get("ticket")
+        if not title:
+            raise ValueError("missing title")
 
-        if not tag or not ticket:
-            raise ValueError("missing tag or team")
+        if not team:
+            raise ValueError("missing team")
 
-        team_id = "{}".format(tag.id)
-        ticket_id = "{}".format(ticket.id)
-        obj_data["id"] = md5(team_id.encode()).hexdigest() + md5(ticket_id.encode()).hexdigest()
-        return super().create(**obj_data)
+        title_id = "{}".format(title.id)
+        team_id = "{}".format(team.id)
+        self.team_title_hash = md5(title_id.encode()).hexdigest() + md5(
+            team_id.encode()).hexdigest()
+
+        super(Tag, self).save(*args, **kwargs)
 
 
 class TicketTag(HasUuid, TeamRelated):
-    id = models.CharField(max_length=256, unique=True, editable=False, primary_key=True)
+    id = models.CharField(max_length=256,
+                          unique=True,
+                          editable=False,
+                          primary_key=True)
     tag = models.ForeignKey(Tag, on_delete=models.CASCADE)
     ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE)
     created = models.DateTimeField(auto_now_add=True)
     activated = models.DateTimeField(null=True, blank=True)
     deactivated = models.DateTimeField(null=True, blank=True)
-    objects = TicketTagManager()
 
     class Meta:
         ordering = ["created"]
@@ -82,13 +74,33 @@ class TicketTag(HasUuid, TeamRelated):
             filters |= models.Q(tag=tag)
 
         # select all that are not in the tag list
-        to_be_deleted = cls.objects.filter(ticket=ticket_instance).exclude(filters)
+        to_be_deleted = cls.objects.filter(
+            ticket=ticket_instance).exclude(filters)
         if to_be_deleted:
             for ticket_tag in to_be_deleted:
                 ticket_tag.delete()
 
         for tag in tag_list:
-            cls.objects.get_or_create(ticket=ticket_instance, tag=tag, team=ticket_instance.team)
+            cls.objects.get_or_create(ticket=ticket_instance,
+                                      tag=tag,
+                                      team=ticket_instance.team)
 
     def __str__(self):
         return f"TicketTag: {self.created}"
+
+    def save(self, *args, **kwargs):
+        tag = self.tag
+        ticket = self.ticket
+
+        if not tag:
+            raise ValueError("missing tag")
+
+        if not ticket:
+            raise ValueError("missing ticket")
+
+        team_id = "{}".format(tag.id)
+        ticket_id = "{}".format(ticket.id)
+        self.id = md5(team_id.encode()).hexdigest() + md5(
+            ticket_id.encode()).hexdigest()
+
+        super(TicketTag, self).save(*args, **kwargs)

--- a/api/models/ticket_tag.py
+++ b/api/models/ticket_tag.py
@@ -33,7 +33,7 @@ class Tag(HasUuid, TeamRelated):
         if not team:
             raise ValueError("missing team")
 
-        title_id = "{}".format(title.id)
+        title_id = "{}".format(title)
         team_id = "{}".format(team.id)
         self.team_title_hash = md5(title_id.encode()).hexdigest() + md5(
             team_id.encode()).hexdigest()


### PR DESCRIPTION
1. All Manager classes have been replaced with overriding the built in `save` function to better fit Django's guidelines, and due to the fact that the timing of when `Manager.create` is called isn't immediately obvious.

2. All models have updated pages in the admin dashboard to allow for proper usage during development. 

3. All admin pages now inherit from the `customAdmin` class, which allows for developers to specify fields that would want to be editable on creation but not once a entry is already created. This allows us to do simple things like not change the `owner` that is associated with a specific `Member`.

4. Made the bio and pronouns field optional in the members class.