### PR TITLE
Add pinned tickets with basic testing

### DIFF
--- a/api/docs.py
+++ b/api/docs.py
@@ -23,3 +23,5 @@ TEAM_LIST_SCHEME = dict(
                          description="A search term used to filter the set"),
     ]
 )
+
+

--- a/api/docs.py
+++ b/api/docs.py
@@ -6,6 +6,7 @@ assorted keys and
 """
 
 TEAM_PK = "team_pk"
+MEMBER_PK = "member_pk"
 
 TEAM_DETAIL_SCHEMA = dict(
     parameters=[

--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -7,3 +7,4 @@ from .ticket_tag import Tag, TicketTag
 from .ticket_node import TicketNode
 from .interfaces.has_uuid import HasUuid
 from .event import Event
+from .pinned_ticket import PinnedTicket

--- a/api/models/member.py
+++ b/api/models/member.py
@@ -7,6 +7,7 @@ import uuid
 
 from api.models.interfaces import HasUuid, TeamRelated
 from .team import Team
+from .ticket import Ticket
 
 User = get_user_model()
 
@@ -59,6 +60,7 @@ class Member(HasUuid, TeamRelated):
     created = models.DateTimeField(auto_now_add=True)
     activated = models.DateTimeField(null=True, blank=True)
     deactivated = models.DateTimeField(null=True, blank=True)
+    pinned_tickets = models.ManyToManyField(Ticket, through='PinnedTicket')
 
     def is_admin(self):
         return self.role == self.Roles.ADMIN

--- a/api/models/member.py
+++ b/api/models/member.py
@@ -60,7 +60,7 @@ class Member(HasUuid, TeamRelated):
     created = models.DateTimeField(auto_now_add=True)
     activated = models.DateTimeField(null=True, blank=True)
     deactivated = models.DateTimeField(null=True, blank=True)
-    pinned_tickets = models.ManyToManyField(Ticket, through='PinnedTicket')
+    pinned_tickets = models.ManyToManyField(Ticket, through='PinnedTicket', blank=True)
 
     def is_admin(self):
         return self.role == self.Roles.ADMIN

--- a/api/models/pinned_ticket.py
+++ b/api/models/pinned_ticket.py
@@ -10,15 +10,15 @@ class PinnedTicket(HasUuid, TeamRelated):
                           unique=True,
                           editable=False,
                           primary_key=True)
-    member = models.ForeignKey(Member, on_delete=models.CASCADE)
-    ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE)
+    member = models.ForeignKey(Member, on_delete=models.CASCADE, editable=False)
+    ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE, editable=False)
     pinned = models.DateTimeField(auto_now_add=True)
 
     class Meta:
         ordering = ["pinned"]
         app_label = "api"
 
-    def save(self, *args, **kwargs):
+    def _pre_create(self):
         member = self.member
         ticket = self.ticket
 
@@ -31,7 +31,12 @@ class PinnedTicket(HasUuid, TeamRelated):
         # Create ID
         member_id = "{}".format(member.id)
         ticket_id = "{}".format(ticket.id)
+
         self.id = md5(member_id.encode()).hexdigest() + md5(ticket_id.encode()).hexdigest()
+
+    def save(self, *args, **kwargs):
+        if self._state.adding:
+            self._pre_create()
 
         super(PinnedTicket, self).save(*args, **kwargs)
 

--- a/api/models/pinned_ticket.py
+++ b/api/models/pinned_ticket.py
@@ -1,0 +1,38 @@
+from django.db import models
+from .member import Member
+from .ticket import Ticket
+from api.models.interfaces import HasUuid, TeamRelated
+from hashlib import md5
+
+
+class PinnedTicket(HasUuid, TeamRelated):
+    id = models.CharField(max_length=256,
+                          unique=True,
+                          editable=False,
+                          primary_key=True)
+    member = models.ForeignKey(Member, on_delete=models.CASCADE)
+    ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE)
+    pinned = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["pinned"]
+        app_label = "api"
+
+    def save(self, *args, **kwargs):
+        member = self.member
+        ticket = self.ticket
+
+        if not member:
+            raise ValueError("Member not provided for pinned ticket relationship")
+
+        if not ticket:
+            raise ValueError("Ticket not provided for pinned ticket relationship")
+
+        # Create ID
+        member_id = "{}".format(member.id)
+        ticket_id = "{}".format(ticket.id)
+        self.id = md5(member_id.encode()).hexdigest() + md5(ticket_id.encode()).hexdigest()
+
+        super(PinnedTicket, self).save(*args, **kwargs)
+
+

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -211,26 +211,21 @@ class TicketSerializer(serializers.ModelSerializer):
 
 
 class PinnedTicketSerializer(serializers.ModelSerializer):
-    ticket = TicketSerializer(many=False, read_only=False)
-    member = serializers.SerializerMethodField()
+    ticket = PrimaryKeySerializedField(many=False,
+                                         required=True,
+                                         queryset=api_models.Ticket.objects.all(),
+                                         serializer=TicketSerializer)
     created = serializers.ReadOnlyField()
     object_uuid = serializers.ReadOnlyField()
 
     class Meta:
         model = api_models.PinnedTicket
-        fields = ["ticket", "member", "pinned", "object_uuid", "created", "id"]
-
-    def get_member(self, obj):
-        return MemberSerializer(obj.member).data
+        fields = ["ticket", "pinned", "object_uuid", "created", "id"]
 
 
 class MemberSerializer(serializers.ModelSerializer):
     id = serializers.ReadOnlyField()
     owner = UserSerializer(many=False, read_only=True)
-    pinned_tickets = PrimaryKeySerializedField(many=True,
-                                               queryset=api_models.Ticket.objects.all(),
-                                               serializer=PinnedTicketSerializer,
-                                               required=False)
     object_uuid = serializers.ReadOnlyField()
     team_id = serializers.ReadOnlyField(source="team.id")
     role = serializers.ReadOnlyField()
@@ -251,7 +246,6 @@ class MemberSerializer(serializers.ModelSerializer):
             "created",
             "activated",
             "deactivated",
-            "pinned_tickets"
         ]
 
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -75,32 +75,6 @@ class TagSerializer(serializers.ModelSerializer):
         ]
 
 
-class MemberSerializer(serializers.ModelSerializer):
-    id = serializers.ReadOnlyField()
-    owner = UserSerializer(many=False, read_only=True)
-    object_uuid = serializers.ReadOnlyField()
-    team_id = serializers.ReadOnlyField(source="team.id")
-    role = serializers.ReadOnlyField()
-    created = serializers.ReadOnlyField()
-    activated = serializers.ReadOnlyField()
-    deactivated = serializers.ReadOnlyField()
-
-    class Meta:
-        model = api_models.Member
-        fields = [
-            "id",
-            "owner",
-            "team_id",
-            "object_uuid",
-            "role",
-            "bio",
-            "pronouns",
-            "created",
-            "activated",
-            "deactivated",
-        ]
-
-
 class TicketCommentSerializer(serializers.ModelSerializer):
     ticket_id = serializers.ReadOnlyField(source="ticket.id")
     team_id = serializers.ReadOnlyField(source="team.id")
@@ -137,7 +111,7 @@ class TicketStatusSerializer(serializers.ModelSerializer):
 
 
 class TicketTagSerializer(serializers.ModelSerializer):
-    tag = TagSerializer(many=False, read_only=True)
+    tag = TagSerializer(many=False, read_only=True, required=False)
     object_uuid = serializers.ReadOnlyField()
     created = serializers.ReadOnlyField()
     activated = serializers.ReadOnlyField()
@@ -233,6 +207,44 @@ class TicketSerializer(serializers.ModelSerializer):
         api_models.TicketTag.delete_difference(tag_list, instance)
 
         return super().update(instance, validated_data)
+
+
+class PinnedTicketSerializer(serializers.ModelSerializer):
+    ticket = TicketSerializer(many=False, read_only=True)
+    created = serializers.ReadOnlyField()
+    object_uuid = serializers.ReadOnlyField()
+
+    class Meta:
+        model = api_models.PinnedTicket
+        fields = ["ticket", "pinned", "object_uuid"]
+
+
+class MemberSerializer(serializers.ModelSerializer):
+    id = serializers.ReadOnlyField()
+    owner = UserSerializer(many=False, read_only=True)
+    pinned_tickets = PrimaryKeySerializedField(many=True, queryset=api_models.Ticket.objects.all(), serializer=PinnedTicketSerializer)
+    object_uuid = serializers.ReadOnlyField()
+    team_id = serializers.ReadOnlyField(source="team.id")
+    role = serializers.ReadOnlyField()
+    created = serializers.ReadOnlyField()
+    activated = serializers.ReadOnlyField()
+    deactivated = serializers.ReadOnlyField()
+
+    class Meta:
+        model = api_models.Member
+        fields = [
+            "id",
+            "owner",
+            "team_id",
+            "object_uuid",
+            "role",
+            "bio",
+            "pronouns",
+            "created",
+            "activated",
+            "deactivated",
+            "pinned_tickets"
+        ]
 
 
 class EventSerializer(serializers.ModelSerializer):

--- a/api/tests/refactored_test.py
+++ b/api/tests/refactored_test.py
@@ -471,7 +471,6 @@ class PinnedTicketTestCase(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.member_not_of_interest_pk = response.data.get('id')
-        print(self.member_not_of_interest_pk)
 
         # Approve second member
         Member.objects.filter(pk=self.member_not_of_interest_pk).update(role=Member.Roles.ADMIN)

--- a/api/urls.py
+++ b/api/urls.py
@@ -46,6 +46,9 @@ team_router.register(
     basename='team-events'
 )
 
+members_router = routers.NestedSimpleRouter(team_router, r'members', lookup='member')
+members_router.register(r'pinned_tickets', views.PinnedTicketViewSet, basename='pinned_tickets')
+
 urlpatterns = [
     # Optional UI:
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
@@ -54,6 +57,7 @@ urlpatterns = [
 
     path("api/", include(router.urls)),
     path("api/", include(team_router.urls)),
+    path("api/", include(members_router.urls)),
 
     path('auth/', include('dj_rest_auth.urls')),
     path('auth/registration/', include('dj_rest_auth.registration.urls')),

--- a/api/urls.py
+++ b/api/urls.py
@@ -47,7 +47,7 @@ team_router.register(
 )
 
 members_router = routers.NestedSimpleRouter(team_router, r'members', lookup='member')
-members_router.register(r'pinned_tickets', views.PinnedTicketViewSet, basename='pinned_tickets')
+members_router.register(r'pinned_tickets', views.PinnedTicketViewSet, basename='pinned-tickets')
 
 urlpatterns = [
     # Optional UI:

--- a/api/views/team_related_views.py
+++ b/api/views/team_related_views.py
@@ -1,6 +1,7 @@
 from .team_related_base import *
 from ..serializers import *
 from ..permissions import *
+from ..docs import *
 
 
 class TeamViewSet(viewsets.ModelViewSet):
@@ -48,6 +49,20 @@ class TicketViewSet(TeamRelatedModelViewSet):
 
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+class PinnedTicketViewSet(TeamRelatedModelViewSet):
+    serializer_class = PinnedTicketSerializer
+    permission_classes = [
+        IsMemberUser, IsOwnerOrReadOnly, IsAuthenticated
+    ]
+
+    def get_member(self):
+        member_id = self.kwargs.get(MEMBER_PK)
+        return get_object_or_404(Member, pk=member_id)
+
+    def get_queryset(self, *args, **kwargs):
+        member_instance = self.get_member()
+        return super().get_queryset(self, *args, **kwargs).filter(member=member_instance)
 
 
 class MemberViewSet(TeamRelatedModelViewSet):

--- a/api/views/team_related_views.py
+++ b/api/views/team_related_views.py
@@ -53,7 +53,7 @@ class TicketViewSet(TeamRelatedModelViewSet):
 class PinnedTicketViewSet(TeamRelatedListMixin,
                         TeamRelatedRetrieveMixin,
                         TeamRelatedDestroyMixin,
-                          TeamRelatedCreateMixin):
+                        TeamRelatedCreateMixin):
     serializer_class = PinnedTicketSerializer
     permission_classes = [
         IsMemberUser, IsOwnerOrReadOnly, IsAuthenticated


### PR DESCRIPTION
PR adds pinned tickets for members, which will enable the functionality to be implemented on the tickets screen + homepage on the SPA.

Note: Testing isn't totally comprehensive, ideally there would be more for authorization; I'd like to revisit that at some point. However, I think it makes more sense to get this merged in so I can resume work on the SPA.