### PR TITLE
Tdimhcsleumas/testing

### DIFF
--- a/api/models/ticket_status.py
+++ b/api/models/ticket_status.py
@@ -31,20 +31,12 @@ class TicketStatus(HasUuid, TeamRelated):
     def _pre_create(self):
         team = self.team
         title = self.title
-        color = self.color
 
         if not title:
             raise ValueError("missing title")
 
         if not team:
             raise ValueError("missing team")
-
-        if not color:
-            color = "#B9B9BD"
-        else:
-            valid = self.check_color(color)
-            if not valid:
-                raise ValueError("invalid color hex code")
 
         title_id = "{}".format(title)
         team_id = "{}".format(team.id)
@@ -54,11 +46,17 @@ class TicketStatus(HasUuid, TeamRelated):
     def save(self, *args, **kwargs):
         if self._state.adding:
             self._pre_create()
+
+        color = self.color
+        valid = self.check_color(color)
+        if not valid:
+            raise ValueError("invalid color hex code")
+
         super(TicketStatus, self).save(*args, **kwargs)
 
     def check_color(self, color):
-        match = re.search(r'^#(?:[0-9a-fA-F]{1,2}){3}$', color)
+        match = re.match(r'^#(?:[0-9a-fA-F]{1,2}){3}$', color)
         if match:
-            return True 
+            return True
         else:
             return False

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -136,18 +136,6 @@ class TicketStatusSerializer(serializers.ModelSerializer):
         ]
 
 
-class TicketTagSerializer(serializers.ModelSerializer):
-    tag = TagSerializer(many=False, read_only=True)
-    object_uuid = serializers.ReadOnlyField()
-    created = serializers.ReadOnlyField()
-    activated = serializers.ReadOnlyField()
-    deactivated = serializers.ReadOnlyField()
-
-    class Meta:
-        model = api_models.TicketTag
-        fields = ["tag", "created", "object_uuid", "activated", "deactivated"]
-
-
 class TicketNodeSerializer(serializers.ModelSerializer):
     ticket_id = serializers.ReadOnlyField()
 

--- a/api/tests/refactored_test.py
+++ b/api/tests/refactored_test.py
@@ -409,7 +409,7 @@ class StatusTestCase(TeamRelatedCore):
         self.detail()
 
     def testUpdate(self):
-        updated_dict = self.data_dict
+        updated_dict = dict(self.data_dict)
         updated_dict["title"] = "alsdkfj"
         updated_dict["color"] = "#F39617"
 
@@ -418,6 +418,21 @@ class StatusTestCase(TeamRelatedCore):
         expected["color"] = updated_dict["color"]
 
         self.update(updated_dict, expected)
+
+    def testBadColor(self):
+        updated_dict = dict(self.data_dict)
+        updated_dict["color"] = "bad"
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        response = client.put(
+            reverse(self.prefix + "-detail", kwargs={
+                "team_pk": self.team.id,
+                "pk": self.pk
+            }), data=updated_dict, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        print(response.data)
 
     def testDelete(self):
         self.delete()


### PR DESCRIPTION
Introduced relatively generic way of validating the output in the tests. Should now have the ability to specify expected output for common crud stuff. Removed TicketTagSerializer because it's neither being used nor should it be used as we don't want to represent m2m helper objects. Combined the existing color tests since they were almost identical to the TicketStatus tests. Currently, the test which relies on the color validation is failing. We ought to write our own field class which encapsulates the validation logic so it's done in the same way as every other field.