### PR TITLE
Disable pinned ticket pagination

### DIFF
--- a/api/tests/refactored_test.py
+++ b/api/tests/refactored_test.py
@@ -517,10 +517,10 @@ class PinnedTicketTestCase(TestCase):
             format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data.get('count'), 1)
+        self.assertEqual(len(response.data), 1)
 
         # Check if holds correct ticket
-        self.assertEqual(response.data.get('results')[0].get('ticket').get('id'), self.ticket_of_interest.pk)
+        self.assertEqual(response.data[0].get('ticket').get('id'), self.ticket_of_interest.pk)
 
     def test_ticket_unpin_removes_access(self):
         response = self.client_of_interest.post(
@@ -547,7 +547,7 @@ class PinnedTicketTestCase(TestCase):
             format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data.get('count'), 0)
+        self.assertEqual(len(response.data), 0)
 
     def test_ticket_pin_does_not_cross_users(self):
         response = self.client_of_interest.post(
@@ -567,4 +567,4 @@ class PinnedTicketTestCase(TestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data.get('count'), 0)
+        self.assertEqual(len(response.data), 0)

--- a/api/views/team_related_views.py
+++ b/api/views/team_related_views.py
@@ -59,6 +59,7 @@ class PinnedTicketViewSet(TeamRelatedListMixin,
         IsMemberUser, IsOwnerOrReadOnly, IsAuthenticated
     ]
     queryset = PinnedTicket.objects.all()
+    pagination_class = None
 
     def get_member(self):
         member_id = self.kwargs.get(MEMBER_PK)


### PR DESCRIPTION
This disables pagination on pinned tickets. It is likely that pagination will not be needed for pinned tickets due to the likelihood of the user having a small number of tickets pinned at any time.

This PR includes the change to disable pagination, as well as modifications required to the tests to implement this.