### PR TITLE
Add pinned tickets to admin dashboard

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from .models import (Ticket, Member, Team, TicketComment, TicketStatus,
-                     TicketNode, TicketTag, Event, Tag)
+                     TicketNode, TicketTag, Event, Tag, PinnedTicket)
 
 
 # Custom Admin class that will allow you to mark fields to be readonly on edits.
@@ -85,3 +85,10 @@ class TicketAdmin(customAdmin):
     fields = ("id", "ticket_number", "team", "owner", "assigned_user",
               "status", "title", "description", "created", "activated",
               "deactivated")
+
+@admin.register(PinnedTicket)
+class PinnedTicketAdmin(customAdmin):
+    readonly_fields = ("id", "member", "ticket", "pinned")
+    readonly_edit = ("team", )
+
+    fields = ("id", "member", "ticket", "pinned", "team")

--- a/api/admin.py
+++ b/api/admin.py
@@ -16,7 +16,7 @@ class customAdmin(admin.ModelAdmin):
 @admin.register(Event)
 class EventAdmin(customAdmin):
     readonly_fields = ("object", "id")
-    readonly_edit = ("team", )
+    readonly_edit = ("team",)
 
     fields = ("id", "team", "event_type", "description", "user")
 
@@ -57,13 +57,13 @@ class TicketCommentAdmin(customAdmin):
 
 @admin.register(TicketNode)
 class TicketNodeAdmin(customAdmin):
-    readonly_fields = ("id", )
+    readonly_fields = ("id",)
 
 
 @admin.register(TicketStatus)
 class TicketStatusAdmin(customAdmin):
     readonly_fields = ("created", "id")
-    readonly_edit = ("team", )
+    readonly_edit = ("team",)
 
     fields = ("id", "team", "title", "color", "created", "activated", "deactivated")
 
@@ -71,7 +71,7 @@ class TicketStatusAdmin(customAdmin):
 @admin.register(TicketTag)
 class TicketTagAdmin(customAdmin):
     readonly_fields = ("created", "id")
-    readonly_edit = ("team", )
+    readonly_edit = ("team",)
 
     fields = ("id", "team", "tag", "ticket", "created", "activated",
               "deactivated")
@@ -80,14 +80,16 @@ class TicketTagAdmin(customAdmin):
 @admin.register(Ticket)
 class TicketAdmin(customAdmin):
     readonly_fields = ("created", "ticket_number", "id", "activated")
-    readonly_edit = ("team", )
+    readonly_edit = ("team",)
 
     fields = ("id", "ticket_number", "team", "owner", "assigned_user",
               "status", "title", "description", "created", "activated",
               "deactivated")
 
+
 @admin.register(PinnedTicket)
 class PinnedTicketAdmin(customAdmin):
-    readonly_fields = ("id", "member", "ticket", "pinned", "team")
+    readonly_fields = ("id", "pinned")
+    readonly_edit = ("member", "ticket", "team")
 
     fields = ("id", "member", "ticket", "pinned", "team")

--- a/api/admin.py
+++ b/api/admin.py
@@ -88,7 +88,6 @@ class TicketAdmin(customAdmin):
 
 @admin.register(PinnedTicket)
 class PinnedTicketAdmin(customAdmin):
-    readonly_fields = ("id", "member", "ticket", "pinned")
-    readonly_edit = ("team", )
+    readonly_fields = ("id", "member", "ticket", "pinned", "team")
 
     fields = ("id", "member", "ticket", "pinned", "team")

--- a/api/models/pinned_ticket.py
+++ b/api/models/pinned_ticket.py
@@ -40,4 +40,8 @@ class PinnedTicket(HasUuid, TeamRelated):
 
         super(PinnedTicket, self).save(*args, **kwargs)
 
+    def __str__(self):
+        return("Ticket pin " + str(self.ticket.id) + " on team " +
+               self.ticket.team.name + " for member " + self.member.owner.username)
+
 

--- a/api/models/pinned_ticket.py
+++ b/api/models/pinned_ticket.py
@@ -8,10 +8,9 @@ from hashlib import md5
 class PinnedTicket(HasUuid, TeamRelated):
     id = models.CharField(max_length=256,
                           unique=True,
-                          editable=False,
                           primary_key=True)
-    member = models.ForeignKey(Member, on_delete=models.CASCADE, editable=False)
-    ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE, editable=False)
+    member = models.ForeignKey(Member, on_delete=models.CASCADE, editable=True)
+    ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE, editable=True)
     pinned = models.DateTimeField(auto_now_add=True)
 
     class Meta:


### PR DESCRIPTION
This adds pinned tickets as read only objects to the admin dashboard. These can be deleted or viewed.

Creating pinned tickets from the dashboard not supported (this can be done with an API call; at some point might add this functionality but I more just want to make sure the pinned tickets are viewable for now).

This also adds a custom str representation to the pinned tickets that makes them more readable.