### PR TITLE
rewrite ticket tag removal logic. update tests to reflect weirdness.

### DIFF
--- a/api/models/ticket_tag.py
+++ b/api/models/ticket_tag.py
@@ -70,24 +70,24 @@ class TicketTag(HasUuid, TeamRelated):
 
     @classmethod
     def delete_difference(cls, tag_list: list, ticket_instance: Ticket):
-        if not tag_list or len(tag_list) <= 0:
-            return
+        if tag_list:
+            filters = models.Q(tag=tag_list[0])
+            for tag in tag_list[1:]:
+                filters |= models.Q(tag=tag)
 
-        filters = models.Q(tag=tag_list.pop(0))
-        for tag in tag_list:
-            filters |= models.Q(tag=tag)
+            # select all that are not in the tag list
+            to_be_deleted = cls.objects.filter(
+                ticket=ticket_instance).exclude(filters)
 
-        # select all that are not in the tag list
-        to_be_deleted = cls.objects.filter(
-            ticket=ticket_instance).exclude(filters)
-        if to_be_deleted:
-            for ticket_tag in to_be_deleted:
-                ticket_tag.delete()
+            for tag in tag_list:
+                cls.objects.get_or_create(ticket=ticket_instance,
+                                          tag=tag,
+                                          team=ticket_instance.team)
+        else:
+            to_be_deleted = cls.objects.filter(ticket=ticket_instance)
 
-        for tag in tag_list:
-            cls.objects.get_or_create(ticket=ticket_instance,
-                                      tag=tag,
-                                      team=ticket_instance.team)
+        for ticket_tag in to_be_deleted:
+            ticket_tag.delete()
 
     def __str__(self):
         return f"TicketTag: {self.created}"

--- a/api/tests/refactored_test.py
+++ b/api/tests/refactored_test.py
@@ -202,6 +202,8 @@ class TicketTestCase(TeamRelatedCore):
             Tag.objects.create(title="to be deleted", team=self.team),
         ]
         ticket_instance = Ticket.objects.get(pk=self.pk)
+        for tag in tags:
+            TicketTag.objects.create(ticket=ticket_instance, team=self.team, tag=tag)
 
         to_be_kept = Tag.objects.create(title="keep this", team=self.team)
         extra_data = dict(self.data_dict)

--- a/api/tests/refactored_test.py
+++ b/api/tests/refactored_test.py
@@ -198,6 +198,24 @@ class TicketTestCase(TeamRelatedCore):
 
     def testRemoveTagOnUpdate(self):
         tags = [
+            Tag.objects.create(title="to be removed", team=self.team),
+            Tag.objects.create(title="to be deleted", team=self.team),
+        ]
+        ticket_instance = Ticket.objects.get(pk=self.pk)
+
+        to_be_kept = Tag.objects.create(title="keep this", team=self.team)
+        extra_data = dict(self.data_dict)
+        extra_data["tag_list"] = [
+            to_be_kept.pk
+        ]
+        expected = TicketSerializer(ticket_instance).data
+        expected["tag_list"] = [
+            TagSerializer(to_be_kept).data
+        ]
+        self.update(extra_data, expected)
+
+    def testRemoveAllTags(self):
+        tags = [
             Tag.objects.create(title="to be kept", team=self.team),
             Tag.objects.create(title="to be deleted", team=self.team),
         ]
@@ -206,13 +224,10 @@ class TicketTestCase(TeamRelatedCore):
             TicketTag.objects.create(ticket=ticket_instance, team=self.team, tag=tag)
 
         extra_data = dict(self.data_dict)
-        extra_data["tag_list"] = [
-            tags[0].pk
-        ]
+        extra_data["tag_list"] = []
+
         expected = TicketSerializer(ticket_instance).data
-        expected["tag_list"] = [
-            TagSerializer(Tag.objects.get(pk=tags[0].pk)).data
-        ]
+        expected["tag_list"] = []
         self.update(extra_data, expected)
 
 
@@ -417,7 +432,6 @@ class StatusTestCase(TeamRelatedCore):
         expected["title"] = updated_dict["title"]
         expected["color"] = updated_dict["color"]
         self.update(updated_dict, expected)
-
 
     def testBadColor(self):
         updated_dict = dict(self.data_dict)


### PR DESCRIPTION
The logic I wrote previously for doing the set difference for tags was incorrect, as I was popping the first element off of the tag_list, thus preventing the first item from being added to the filters. The second issue was the return when tag_list is empty. Now the code should be correct.
Resolves #40 